### PR TITLE
Ahrs99/support_dots_in_between_of_usernames

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,7 +33,7 @@ class MyApp extends StatelessWidget {
                 child: RichTextView(
                   text:
                       '''Who else thinks it's thinks it's just cool to mention 
-                      @jane when #JaneMustLive is trending without even trying 
+                      @jane.id_ when #JaneMustLive is trending without even trying 
                       to send a *bold* email to janedoe@gmail.com and verify the
                        facts talkmore of visiting www.janedoe.com''',
                   maxLines: 3,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,7 +33,7 @@ class MyApp extends StatelessWidget {
                 child: RichTextView(
                   text:
                       '''Who else thinks it's thinks it's just cool to mention 
-                      @jane.id_ when #JaneMustLive is trending without even trying 
+                      @jane.h when #JaneMustLive is trending without even trying 
                       to send a *bold* email to janedoe@gmail.com and verify the
                        facts talkmore of visiting www.janedoe.com''',
                   maxLines: 3,

--- a/lib/src/suggestion/widget.dart
+++ b/lib/src/suggestion/widget.dart
@@ -15,11 +15,7 @@ class SearchItemWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var state = suggestionController.state;
-    var border = BorderSide(
-        width: Theme.of(context).brightness == Brightness.dark ? 0.1 : 1.0,
-        color: state.suggestionHeight > 1
-            ? Colors.grey[200]!
-            : Colors.transparent);
+    var border = BorderSide.none;
     return Container(
         constraints: BoxConstraints(
           minHeight: 0,

--- a/lib/src/suggestion/widget.dart
+++ b/lib/src/suggestion/widget.dart
@@ -22,7 +22,7 @@ class SearchItemWidget extends StatelessWidget {
             : Colors.transparent);
     return Container(
         constraints: BoxConstraints(
-          minHeight: 1,
+          minHeight: 0,
           maxHeight: state.suggestionHeight,
           maxWidth: double.infinity,
           minWidth: double.infinity,

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -13,5 +13,5 @@ class RTUtils {
   static const String starPattern = r'\*.*?\*';
   static const boldPattern = r'\*.*?\*';
   static const hashPattern = r'\B#+([^\x00-\x7F]|\w)+';
-  static const mentionPattern = r'\B@+([\w]+)\b';
+  static const mentionPattern = r'\B@+([\w+.]+)\b';
 }


### PR DESCRIPTION
This modification provides the ability to utilize this package in applications where users are allowed to have a dot in their usernames. If the character after the dot is blank, the dot would not be considered as a part of the username since in this scenario the dot is most probably the period ending the sentence (also most applications won’t let users have usernames ending with a period e.g. Instagram).