### PR TITLE
regex email pattern improvement

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,6 +1,7 @@
 class RTUtils {
   /// Email Regex - A predefined type for handling email matching
-  static const emailPattern = r'\b[\w\.-]+@[\w\.-]+\.\w{2,4}\b';
+  static const emailPattern = 
+    r'''(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])''';
 
   /// URL Regex - A predefined type for handling URL matching
   static const urlPattern =


### PR DESCRIPTION
The current regex pattern works for simple formats, but it doesn't check for filters;
It doesn't accept filters, like test+test@test.test

The change I would like to suggest is to follow the RFC 5322 standard.
This is a standard format for emails.

The pattern to match this standard is from https://www.regextester.com/115911